### PR TITLE
rails db:prepare で test データベースが生成されない不具合解消

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -29,7 +29,7 @@ FileUtils.chdir APP_ROOT do
   system! 'bin/rails db:prepare'
 
   puts "\n== Removing old logs and tempfiles =="
-  system! 'bin/rails log:clear tmp:clear'
+  system! 'bin/rails log:clear tmp:clear tmp:pids:clear'
 
   puts "\n== Restarting application server =="
   system! 'bin/rails restart'

--- a/config/database.yml
+++ b/config/database.yml
@@ -2,6 +2,7 @@ default: &default
   adapter: postgresql
   encoding: unicode
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  url: <%= ENV['DATABASE_URL'] %>
 
 development:
   <<: *default
@@ -14,5 +15,3 @@ test:
 production:
   <<: *default
   database: tenmei_dic_production
-  username: tenmei_dic
-  password: <%= ENV['TENMEI_DIC_DATABASE_PASSWORD'] %>


### PR DESCRIPTION
database.yml で DATABASE_URL を使うときには明示的に
`url: <%= ENV['DATABASE_URL'] %>`
を渡さないとダメだった


`tmp:pids:clear` の追加はついで。
これがあるとpidが生き残ったまま終了しても削除してくれる。